### PR TITLE
chore: Drop unsupported TFMs

### DIFF
--- a/src/Twilio/Http/SystemNetHttpClient.cs
+++ b/src/Twilio/Http/SystemNetHttpClient.cs
@@ -13,8 +13,8 @@ namespace Twilio.Http
     /// </summary>
     public class SystemNetHttpClient : HttpClient
     {
-#if NET451
-        private string PlatVersion = ".NET Framework 4.5.1+";
+#if NET462
+        private string PlatVersion = ".NET Framework 4.6.2+";
 #else
         private string PlatVersion = RuntimeInformation.FrameworkDescription;
 #endif
@@ -98,9 +98,9 @@ namespace Twilio.Http
             string helperLibVersion = AssemblyInfomation.AssemblyInformationalVersion;
 
             string osName = "Unknown";
-#if !NETSTANDARD1_4
+#if !NETSTANDARD2_0
             osName = Environment.OSVersion.Platform.ToString();
-#else       
+#else
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 osName = "Windows";
@@ -116,7 +116,7 @@ namespace Twilio.Http
 #endif
 
             string osArch;
-#if !NET451
+#if !NET462
             osArch = RuntimeInformation.OSArchitecture.ToString();
 #else
             osArch = Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE") ?? "Unknown"; 

--- a/src/Twilio/Twilio.csproj
+++ b/src/Twilio/Twilio.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="NuGet">
-    <TargetFrameworks>netstandard1.4;netstandard2.0;net451;net35</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net35;net462</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageId>Twilio</PackageId>
     <Description>Twilio REST API helper library</Description>
@@ -8,8 +8,7 @@
     <AssemblyTitle>Twilio</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
     <VersionPrefix>6.2.0</VersionPrefix>
-    <VersionSuffix>
-    </VersionSuffix>
+    <VersionSuffix></VersionSuffix>
     <Authors>Twilio</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
@@ -21,17 +20,10 @@
     <PackageLicenseUrl>https://github.com/twilio/twilio-csharp/blob/HEAD/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>http://github.com/twilio/twilio-csharp</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.4' ">1.6.1</NetStandardImplicitPackageVersion>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">2.0.0</NetStandardImplicitPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Xml.Linq" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.2" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="5.1.2" />
-    <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
@@ -39,7 +31,7 @@
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.19.0" />
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.2" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="5.1.2" />

--- a/test/Twilio.Test/Twilio.Test.csproj
+++ b/test/Twilio.Test/Twilio.Test.csproj
@@ -2,23 +2,24 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>Twilio.Tests</RootNamespace>
-    <TargetFrameworks>netcoreapp2.0;net451;net35</TargetFrameworks>
-    <RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net451' ">win7-x86</RuntimeIdentifier>
+    <TargetFrameworks>net60;net462;net35</TargetFrameworks>
+    <RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net462' ">win7-x86</RuntimeIdentifier>
     <RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net35' ">win7-x86</RuntimeIdentifier>
     <IsPackable>false</IsPackable>
+	<GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="NUnit" Version="3.6.0" />
-    <PackageReference Include="NSubstitute" Version="2.0.0-rc" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="NUnitLite" Version="3.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NSubstitute" Version="2.0.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="NUnitLite" Version="3.13.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>


### PR DESCRIPTION
**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Fixes #667

# Fixes #

Removes the .NET target frameworks that Microsoft doesn't support any longer.
This will let you use newer APIs, speed up the build, and reduce the download size of the NuGet package.

(I also fixed some issues with the Twilio.csproj and updated the Twilio.Test dependencies to get the projects to work)

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-csharp/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
